### PR TITLE
Windows compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Please report any issues at https://github.com/mulesoft-labs/log4j2-migrator/iss
 ## Usage
 groovy log4jmigrator.grovvy pathname-to-log4j.properties
 
+### Options
+
+ -d,--debug          print debug information
+ -h,--help           usage information
+ -o,--output <arg>   file to write the output
+
 ## Example
 
 ```

--- a/log4j2migrator.groovy
+++ b/log4j2migrator.groovy
@@ -1,4 +1,4 @@
-def cli = new CliBuilder(usage: 'log4j2-migrator [options] input-file')
+def cli = new groovy.cli.commons.CliBuilder(usage: 'log4j2-migrator [options] input-file')
 cli.with {
     h(longOpt: 'help', 'usage information', required: false)
     o(longOpt: 'output', 'file to write the output', required: false, args: 1)
@@ -7,7 +7,7 @@ cli.with {
     a(longOpt: 'async', 'use async loggers', required: false, args: 1, defaultValue: "false", type: Boolean)
 }
 
-OptionAccessor opt = cli.parse(args)
+groovy.cli.commons.OptionAccessor opt = cli.parse(args)
 if (!opt) {
     return
 }

--- a/log4j2migrator.groovy
+++ b/log4j2migrator.groovy
@@ -156,31 +156,31 @@ def generate(bindings) {
       }
       def additivites = bindings['additivities']
       'Loggers' {
-                bindings['loggers'].each { name, value ->
-                    def loggerName = 'Logger'
-                    if (async) {
-                        loggerName = 'AsyncLogger'
-                    }
-                    "$loggerName" (name:name, level:value[0].trim(), additivity: additivites[name] ?: 'false') {
-                        if (value.size() > 1) {
-                            def loggerAppenders = value[1..-1]
-                            loggerAppenders.each {
-                                'AppenderRef' (ref:it.trim())
-                            }
+            bindings['loggers'].each { name, value ->
+                def loggerName = 'Logger'
+                if (async) {
+                    loggerName = 'AsyncLogger'
+                }
+                "$loggerName" (name:name, level:value[0].trim(), additivity: additivites[name] ?: 'false') {
+                    if (value.size() > 1) {
+                        def loggerAppenders = value[1..-1]
+                        loggerAppenders.each {
+                            'AppenderRef' (ref:it.trim())
                         }
                     }
                 }
-                def loggerName = 'Root'
-                if (async) {
-                    loggerName = 'AsyncRoot'
-                }
-                "$loggerName" (level:bindings['rootLevel']) {
-                    bindings['rootAppenders'].each { name ->
-                        AppenderRef (ref:name.trim())
-                    }
+            }
+            def loggerName = 'Root'
+            if (async) {
+                loggerName = 'AsyncRoot'
+            }
+            "$loggerName" (level:bindings['rootLevel']) {
+                bindings['rootAppenders'].each { name ->
+                    AppenderRef (ref:name.trim())
                 }
             }
         }
+    }
 
     xmlWriter.append(System.getProperty("line.separator"))
     return xmlWriter.toString()

--- a/log4j2migrator.groovy
+++ b/log4j2migrator.groovy
@@ -1,35 +1,35 @@
 def cli = new CliBuilder(usage: 'log4j2-migrator [options] input-file')
 cli.with {
-    h(longOpt: 'help'  , 'usage information'   , required: false )
-    o(longOpt: 'output', 'file to write the output', required: false  , args: 1 )
-    d(longOpt: 'debug', 'print debug information', required: false  )
-    i(longOpt: 'interpolate', 'substitue parameters', required: false )
+    h(longOpt: 'help', 'usage information', required: false)
+    o(longOpt: 'output', 'file to write the output', required: false, args: 1)
+    d(longOpt: 'debug', 'print debug information', required: false )
+    i(longOpt: 'interpolate', 'substitue parameters', required: false)
 }
 
 OptionAccessor opt = cli.parse(args)
-if(!opt) {
+if (!opt) {
     return
 }
 
 // print usage if -h or --help or number of arguments incorrect
-if(opt.h || opt.arguments().size() != 1) {
+if (opt.h || opt.arguments().size() != 1) {
     cli.usage()
     return
 }
 
 def outputFile
-if( opt.o ) {
+if (opt.o) {
     outputFile = opt.o
-} 
+}
 
 @groovy.transform.Field def debug // global print debug information flag
-if( opt.d ) {
+if (opt.d) {
     debug = opt.d
-} 
+}
 
 @groovy.transform.Field def interpolate
-if ( opt.i ) {
-  interpolate = opt.i
+if (opt.i) {
+    interpolate = opt.i
 }
 
 def extraArguments = opt.arguments()
@@ -43,12 +43,11 @@ propertiesFile.withInputStream {
     properties.load(it)
 }
 
-
 def bindings = parse(properties)
 
 if (debug) { System.err.println "Bindings = ${bindings}" }
 
-def output=generate(bindings)
+def output = generate(bindings)
 
 if (outputFile) {
     new File(outputFile).write(output)
@@ -56,85 +55,78 @@ if (outputFile) {
     println output
 }
 
-
-
 def parse(properties) {
+    def appenders = [:]
+    def loggers = [:]
+    def additivities = [:]
+    def rootLevel
+    def rootAppenders
+    def params = [:]
 
-	def appenders=[:]
-	def loggers=[:]
-    def additivities=[:]
-	def rootLevel
-	def rootAppenders
+    properties.each { key, value ->
+        value = value.trim()
+        if (interpolate) {
+            value = value.replaceAll(/\$\{(.*?)\}/) { m, k -> params[k] }
+            params[key] = value
+        }
+        if (debug) { System.err.println "property ${key}=[${value}]" }
 
-        def params=[:]
-
-	properties.each { key, value ->
-        value=value.trim()
-                if ( interpolate ) {
-                    value = value.replaceAll(/\$\{(.*?)\}/) { m, k -> params[k] }
-                    params[key]=value
-                }
-		if (debug) { System.err.println "property ${key}=[${value}]" }
-
-		if (key.startsWith("log4j.appender")) {
-			def (log4j, appender, name, property,extra)=key.tokenize('.')
-			if (debug) { System.err.println "log4j=${log4j}, appender=${appender}, name=${name}, property=${property}, extra=${extra}, value=${value}" }
-			if (!appenders.containsKey(name)) {
-				appenders[name] = [:]
-			}
-			if (property == null) {
-				if (value == "org.apache.log4j.ConsoleAppender") {
-					appenders[name]['type']='Console'
-				} else if (value == "org.apache.log4j.DailyRollingFileAppender") {
-					appenders[name]['type']='DailyRollingFile'
-				} else if (value == "org.apache.log4j.RollingFileAppender") {
-					appenders[name]['type']='RollingFile'
-				} else {
+        if (key.startsWith('log4j.appender')) {
+            def (log4j, appender, name, property,extra)=key.tokenize('.')
+            if (debug) { System.err.println "log4j=${log4j}, appender=${appender}, name=${name}, property=${property}, extra=${extra}, value=${value}" }
+            if (!appenders.containsKey(name)) {
+                appenders[name] = [:]
+            }
+            if (property == null) {
+                if (value == 'org.apache.log4j.ConsoleAppender') {
+                    appenders[name]['type'] = 'Console'
+                } else if (value == 'org.apache.log4j.DailyRollingFileAppender') {
+                    appenders[name]['type'] = 'DailyRollingFile'
+                } else if (value == 'org.apache.log4j.RollingFileAppender') {
+                    appenders[name]['type'] = 'RollingFile'
+                } else {
                     System.err.println "WARNING: unknown appender type ${value} ignored!"
                 }
-			} else {
-				appenders[name][property]=value
-			}
-			if (extra != null) {
-				appenders[name]['pattern']=value
-			}
-		} else if (key.startsWith("log4j.logger.")) {
-            def loggerName = key.substring("log4j.logger.".size())
+            } else {
+                appenders[name][property] = value
+            }
+            if (extra != null) {
+                appenders[name]['pattern'] = value
+            }
+        } else if (key.startsWith('log4j.logger.')) {
+            def loggerName = key.substring('log4j.logger.'.size())
             loggers[loggerName] = value.tokenize(',')
-        } else if (key.startsWith("log4j.category.")) {
-            def loggerName = key.substring("log4j.category.".size())
+        } else if (key.startsWith('log4j.category.')) {
+            def loggerName = key.substring('log4j.category.'.size())
             loggers[loggerName] = value.tokenize(',')
-        } else if (key.startsWith("log4j.additivity.")) {
-            def loggerName = key.substring("log4j.additivity.".size())
+        } else if (key.startsWith('log4j.additivity.')) {
+            def loggerName = key.substring('log4j.additivity.'.size())
             additivities[loggerName] = value
-		} else if (key.startsWith("log4j.rootCategory") || key.startsWith("log4j.rootLogger")) {
-			def rootCategories = value.tokenize( ',' )
+        } else if (key.startsWith('log4j.rootCategory') || key.startsWith('log4j.rootLogger')) {
+            def rootCategories = value.tokenize( ',' )
             rootLevel = rootCategories[0]
             rootAppenders = rootCategories.size() > 1 ? rootCategories[1..-1] : []
-		} else {
+        } else {
             System.err.println "WARNING: unknown property ${key} ignored!"
         }
-	}
-	
-    def values = ['rootLevel': rootLevel, 'rootAppenders':rootAppenders, 'appenders': appenders,
-                  'loggers': loggers, 'additivities': additivities]
+    }
 
-	return values
+    def values = ['rootLevel': rootLevel, 'rootAppenders':rootAppenders, 'appenders': appenders, 'loggers': loggers, 'additivities': additivities]
+    return values
 }
 
 def generate(bindings) {
-    def xmlWriter = new StringWriter() 
+    def xmlWriter = new StringWriter()
     def xmlMarkup = new groovy.xml.MarkupBuilder(xmlWriter)
     xmlMarkup.setOmitNullAttributes(true)
     xmlMarkup.setDoubleQuotes(true)
-    xmlMarkup.mkp.xmlDeclaration(version: "1.0", encoding: "utf-8")
+    xmlMarkup.mkp.xmlDeclaration(version: '1.0', encoding: 'utf-8')
     xmlMarkup
         .'Configuration' {
             'Appenders' {
-                bindings['appenders'].each { name, values -> 
-
+                bindings['appenders'].each { name, values ->
                     if (values['type'] == 'Console') {
-                        def target = 'SYSTEM_OUT' 
+                        def target = 'SYSTEM_OUT'
                         if (values['target'] == 'System.err') { target = 'SYSTEM_ERR' }
                         'Console'(name: name, target:target) {
                             'PatternLayout'(pattern:values['pattern'])
@@ -144,7 +136,7 @@ def generate(bindings) {
                             mkp.comment('TODO filePattern is autogenerated. Please review. ')
                             'PatternLayout'(pattern:values['pattern'])
                             'TimeBasedTriggeringPolicy' ()
-                        }                        
+                        }
                     } else if (values['type'] == 'RollingFile') {
                         'RollingFile'(name:name, fileName:values['File'], filePattern:"${fileName:values['File']}.%i") {
                             'PatternLayout'(pattern:values['pattern'])
@@ -155,9 +147,9 @@ def generate(bindings) {
                         }
                     }
                 }
-            }
-            def additivites = bindings['additivities']
-            'Loggers' {
+      }
+      def additivites = bindings['additivities']
+      'Loggers' {
                 bindings['loggers'].each { name, value ->
                     'AsyncLogger' (name:name, level:value[0].trim(), additivity: additivites[name] ?: 'false') {
                         if (value.size() > 1) {
@@ -173,8 +165,7 @@ def generate(bindings) {
                         AppenderRef (ref:name.trim())
                     }
                 }
-            }
+      }
         }
     return xmlWriter.toString()
-
 }

--- a/log4j2migrator.groovy
+++ b/log4j2migrator.groovy
@@ -115,8 +115,10 @@ def generate(bindings) {
             'Appenders' {
                 bindings['appenders'].each { name, values -> 
 
-                    if (values['type'] == 'Console') { 
-                        'Console'(name: name, target:'SYSTEM_OUT') {
+                    if (values['type'] == 'Console') {
+                        def target = 'SYSTEM_OUT' 
+                        if (values['target'] == 'System.err') { target = 'SYSTEM_ERR' }
+                        'Console'(name: name, target:target) {
                             'PatternLayout'(pattern:values['pattern'])
                         }
                     } else if (values['type'] == 'DailyRollingFile') {

--- a/test/log4j-console-err.properties
+++ b/test/log4j-console-err.properties
@@ -1,0 +1,26 @@
+# Log console to system error
+log4j.rootCategory=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%-5p %d [%t] %c: %m%n
+
+################################################
+# You can set custom log levels per-package here
+################################################
+
+# CXF is used heavily by Mule for web services
+log4j.logger.org.apache.cxf=WARN
+
+# Apache Commons tend to make a lot of noise which can clutter the log.
+log4j.logger.org.apache=WARN
+
+# Reduce startup noise
+log4j.logger.org.springframework.beans.factory=WARN
+
+# Mule classes
+log4j.logger.org.mule=INFO
+
+
+#log4j.logger.httpclient.wire=DEBUG


### PR DESCRIPTION
Unsure why, but received the following errors when running on Windows through git-bash:

```bash
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
D:\apps\log4j2migrator.groovy: 1: unable to resolve class CliBuilder
 @ line 1, column 11.
   def cli = new CliBuilder(usage: 'log4j2-migrator [options] input-file')
             ^

D:\apps\log4j2migrator.groovy: 10: unable to resolve class OptionAccessor
 @ line 10, column 16.
   OptionAccessor opt = cli.parse(args)
                  ^

2 errors
```

Specifying the full package works on both.

Original script was tested on Mac with Groovy version 3.0.9, while Groovy on Windows is 4.0.0.
